### PR TITLE
added support for .docm, .xlsm and .xls file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Evil Clippy compiles perfectly fine with the Mono C# compiler and has been teste
 **OSX and Linux**
 Make sure you have Mono installed. Then execute the following command from the command line:
 
-`mcs /reference:OpenMcdf.dll /out:EvilClippy.exe *.cs`
+`mcs /reference:OpenMcdf.dll,System.IO.Compression.FileSystem.dll /out:EvilClippy.exe *.cs`
 
 Now run Evil Clippy from the command line:
 
@@ -38,7 +38,7 @@ Now run Evil Clippy from the command line:
 **Windows**
 Make sure you have Visual Studio installed. Then execute the following command from a Visual Studio developer command prompt:
 
-`csc /reference:OpenMcdf.dll /out:EvilClippy.exe *.cs`
+`csc /reference:OpenMcdf.dll,System.IO.Compression.FileSystem.dll /out:EvilClippy.exe *.cs`
 
 Now run Evil Clippy from the command line:
 
@@ -62,6 +62,8 @@ Put fake VBA code from text file *fakecode.vba* in all modules, while leaving P-
 
 `EvilClippy.exe -s fakecode.vba macrofile.doc`
 
+Note: VBA Stomping does not work for files saved in the Excel 97-2003 Workbook (.xls) format
+
 **Set target Office version for VBA stomping**
 
 Same as the above, but now explicitly targeting Word 2016 on x86. This means that Word 2016 on x86 will execute the P-code, while other versions of Word wil execute the code from *fakecode.vba* instead. Achieved by setting the appropriate version bytes in the _VBA_PROJECT stream [MS-OVBA 2.3.4.1].
@@ -74,6 +76,8 @@ Set random ASCII module names in the dir stream [MS-OVBA 2.3.4.2]. This abuses a
 
 `EvilClippy.exe -r macrofile.doc`
 
+Note: this is known to be effective in tricking oletools olevba.py module when run against Word 97-2003 Documents (.doc)
+
 **Serve a VBA stomped template via HTTP**
 
 Service *macrofile.dot* via HTTP port 8080 after performing VBA stomping. If this file is retrieved, it automatically matches the target's Office version (using its HTTP headers and then setting the _VBA_PROJECT bytes accordingly).
@@ -84,9 +88,9 @@ Note: The file you are serving must be a template (.dot instead of .doc). Also, 
 
 ## Limitations
 
-The current version only works with the CFBF-based Office 97-2003 format for Word (the famous .doc files). The newer XML-based format (.docm) is not yet supported. Neither is Excel (.xls and .xlsm). 
+Developed for Microsoft Word and Excel document manipulation.
 
-All of these lacking features might be added in future releases.
+As noted above, VBA stomping is not effective against Excel 97-2003 Workbook (.xls) format.
 
 ## Authors
 Stan Hegt ([@StanHacked](https://twitter.com/StanHacked)) / [Outflank](https://www.outflank.nl)

--- a/evilclippy.cs
+++ b/evilclippy.cs
@@ -6,8 +6,8 @@
 // Version: 1.0
 //  
 // Compilation instructions
-// Mono: mcs /reference:OpenMcdf.dll /out:EvilClippy.exe *.cs 
-// Visual studio developer command prompt: csc /reference:OpenMcdf.dll /out:EvilClippy.exe *.cs 
+// Mono: mcs /reference:OpenMcdf.dll,System.IO.Compression.FileSystem.dll /out:EvilClippy.exe *.cs 
+// Visual studio developer command prompt: csc /reference:OpenMcdf.dll,System.IO.Compression.FileSystem.dll /out:EvilClippy.exe *.cs 
 
 using System;
 using OpenMcdf;
@@ -19,12 +19,13 @@ using NDesk.Options;
 using System.Net;
 using System.Threading;
 using System.IO;
- 
+using System.IO.Compression;
+
 public class MSOfficeManipulator
 {
 	// Verbosity level for debug messages
 	static int verbosity = 0;
-	
+
 	// Filename of the document that is about to be manipulated
 	static string filename = "";
 
@@ -36,14 +37,14 @@ public class MSOfficeManipulator
 	static byte[] dirStream;
 	static byte[] projectStream;
 
-    static public void Main (string[] args)
-    {
-    	// List of target VBA modules to stomp, if empty => all modules will be stomped
-    	List<string> targetModules = new List<string> ();
+	static public void Main(string[] args)
+	{
+		// List of target VBA modules to stomp, if empty => all modules will be stomped
+		List<string> targetModules = new List<string>();
 
 		// Filename that contains the VBA code used for substitution
 		string VBASourceFileName = "";
-		
+
 		// Target MS Office version for pcode
 		string targetOfficeVersion = "";
 
@@ -55,16 +56,23 @@ public class MSOfficeManipulator
 
 		// Option to display help
 		bool optionShowHelp = false;
-		
+
+		// File format is OpenXML (docm or xlsm)
+		bool is_OpenXML = false;
+
 		// Option to delete metadata from file
 		bool optionDeleteMetadata = false;
-		
+
 		// Option to set random module names in dir stream
 		bool optionSetRandomNames = false;
 
-    	// Start parsing command line arguments
-		var p = new OptionSet () {
-			{ "n|name=", "The target module name to stomp.\n" + 
+		// Temp path to unzip OpenXML files to
+		String unzipTempPath = "";
+
+
+		// Start parsing command line arguments
+		var p = new OptionSet() {
+			{ "n|name=", "The target module name to stomp.\n" +
 				"This argument can be repeated.",
 				v => targetModules.Add (v) },
 			{ "s|sourcefile=", "File containing substitution VBA code (fake code).",
@@ -72,58 +80,88 @@ public class MSOfficeManipulator
 			{ "g|guihide", "Hide code from VBA editor GUI.",
 				v => optionHideInGUI = v != null },
 			{ "t|targetversion=", "Target MS Office version the pcode will run on.",
-				v => targetOfficeVersion = v },				
+				v => targetOfficeVersion = v },
 			{ "w|webserver=", "Start web server on specified port to serve malicious template.",
-				(int v) => optionWebserverPort = v },				
+				(int v) => optionWebserverPort = v },
 			{ "d|delmetadata", "Remove metadata stream (may include your name etc.).",
 				v => optionDeleteMetadata = v != null },
 			{ "r|randomnames", "Set random module names, confuses some analyst tools.",
-				v => optionSetRandomNames = v != null },				
+				v => optionSetRandomNames = v != null },
 			{ "v", "Increase debug message verbosity.",
 				v => { if (v != null) ++verbosity; } },
-			{ "h|help",  "Show this message and exit.", 
+			{ "h|help",  "Show this message and exit.",
 				v => optionShowHelp = v != null },
 		};
 
 		List<string> extra;
-		try {
-			extra = p.Parse (args);
+		try
+		{
+			extra = p.Parse(args);
 		}
-		catch (OptionException e) {
-			Console.WriteLine (e.Message);
-			Console.WriteLine ("Try '--help' for more information.");
+		catch (OptionException e)
+		{
+			Console.WriteLine(e.Message);
+			Console.WriteLine("Try '--help' for more information.");
 			return;
 		}
 
-        if (extra.Count > 0) {
-            filename = string.Join (" ", extra.ToArray ());
-        }
-        else {
+		if (extra.Count > 0)
+		{
+			filename = string.Join(" ", extra.ToArray());
+		}
+		else
+		{
 			optionShowHelp = true;
-        }		
+		}
 
-        if (optionShowHelp) {
-            ShowHelp (p);
-            return;
-        }
-        // End parsing command line arguments
+		if (optionShowHelp)
+		{
+			ShowHelp(p);
+			return;
+		}
+		// End parsing command line arguments
+
+		// OLE Filename (make a copy so we don't overwrite the original)
+		string outFilename = getOutFilename(filename);
+		string oleFilename = outFilename;
+
+		// Attempt to unzip as docm or xlsm OpenXML format
+		try
+		{
+			unzipTempPath = CreateUniqueTempDirectory();
+			ZipFile.ExtractToDirectory(filename, unzipTempPath);
+			if (File.Exists(Path.Combine(unzipTempPath, "word", "vbaProject.bin"))) { oleFilename = Path.Combine(unzipTempPath, "word", "vbaProject.bin"); }
+			else if (File.Exists(Path.Combine(unzipTempPath, "xl", "vbaProject.bin"))) { oleFilename = Path.Combine(unzipTempPath, "xl", "vbaProject.bin"); }
+			is_OpenXML = true;
+		}
+		catch (Exception)
+		{
+			// Not OpenXML format, Maybe 97-2003 format, Make a copy
+			if (File.Exists(outFilename)) File.Delete(outFilename);
+			File.Copy(filename, outFilename);
+		}
 
 		// Open OLE compound file for editing
-		try {
-			cf = new CompoundFile(filename, CFSUpdateMode.Update, 0);
+		try
+		{
+			cf = new CompoundFile(oleFilename, CFSUpdateMode.Update, 0);
 		}
-		catch (Exception e) {
+		catch (Exception e)
+		{
 			Console.WriteLine("ERROR: Could not open file " + filename);
-			Console.WriteLine("Please make sure this file exists and is a .doc in the Office 97-2003 format.");
+			Console.WriteLine("Please make sure this file exists and is .docm or .xlsm file or a .doc in the Office 97-2003 format.");
 			Console.WriteLine();
 			Console.WriteLine(e.Message);
 			return;
 		}
-		
-		// Read relevant streams		
-		vbaProjectStream = cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("_VBA_PROJECT").GetData();
-		projectStream = cf.RootStorage.GetStorage("Macros").GetStream("project").GetData();
-		dirStream = Decompress(cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("dir").GetData());
+
+        // Read relevant streams
+        CFStorage commonStorage = cf.RootStorage; // docm or xlsm
+		if (cf.RootStorage.TryGetStorage("Macros") != null) commonStorage = cf.RootStorage.GetStorage("Macros"); // .doc
+		if (cf.RootStorage.TryGetStorage("_VBA_PROJECT_CUR") != null) commonStorage = cf.RootStorage.GetStorage("_VBA_PROJECT_CUR"); // xls		
+		vbaProjectStream = commonStorage.GetStorage("VBA").GetStream("_VBA_PROJECT").GetData();
+		projectStream = commonStorage.GetStream("project").GetData();
+		dirStream = Decompress(commonStorage.GetStorage("VBA").GetStream("dir").GetData());
 
 		// Read project stream as string
 		string projectStreamString = System.Text.Encoding.UTF8.GetString(projectStream);
@@ -134,182 +172,226 @@ public class MSOfficeManipulator
 		// Write streams to debug log (if verbosity enabled)
 		DebugLog("Hex dump of original _VBA_PROJECT stream:\n" + Utils.HexDump(vbaProjectStream));
 		DebugLog("Hex dump of original dir stream:\n" + Utils.HexDump(dirStream));
-		DebugLog("Hex dump of original project stream:\n" + Utils.HexDump(projectStream));		
-	
+		DebugLog("Hex dump of original project stream:\n" + Utils.HexDump(projectStream));
+
 		// Replace Office version in _VBA_PROJECT stream
-		if (targetOfficeVersion != "") {
+		if (targetOfficeVersion != "")
+		{
 			ReplaceOfficeVersionInVBAProject(vbaProjectStream, targetOfficeVersion);
-			cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("_VBA_PROJECT").SetData(vbaProjectStream);
+			commonStorage.GetStorage("VBA").GetStream("_VBA_PROJECT").SetData(vbaProjectStream);
 		}
-			
+
 		// Hide modules from GUI
-		if (optionHideInGUI) {
-			foreach (var vbaModule in vbaModules) {	
-				if ((vbaModule.moduleName != "ThisDocument") && (vbaModule.moduleName != "ThisWorkbook")) {
+		if (optionHideInGUI)
+		{
+			foreach (var vbaModule in vbaModules)
+			{
+				if ((vbaModule.moduleName != "ThisDocument") && (vbaModule.moduleName != "ThisWorkbook"))
+				{
 					Console.WriteLine("Hiding module: " + vbaModule.moduleName);
 					projectStreamString = projectStreamString.Replace("Module=" + vbaModule.moduleName, "");
 				}
 			}
-			
+
 			// Write changes to project stream
-			cf.RootStorage.GetStorage("Macros").GetStream("project").SetData(Encoding.UTF8.GetBytes(projectStreamString));
+			commonStorage.GetStream("project").SetData(Encoding.UTF8.GetBytes(projectStreamString));
 		}
-	
+
 		// Stomp VBA modules
-		if (VBASourceFileName != "") {
+		if (VBASourceFileName != "")
+		{
 			byte[] streamBytes;
 
-			foreach (var vbaModule in vbaModules) {
+			foreach (var vbaModule in vbaModules)
+			{
 				DebugLog("VBA module name: " + vbaModule.moduleName + "\nOffset for code: " + vbaModule.textOffset);
-			
+
 				// If this module is a target module, or if no targets are specified, then stomp
-				if (targetModules.Contains(vbaModule.moduleName) || !targetModules.Any()) {
+				if (targetModules.Contains(vbaModule.moduleName) || !targetModules.Any())
+				{
 					Console.WriteLine("Now stomping VBA code in module: " + vbaModule.moduleName);
-			
-					streamBytes = cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream(vbaModule.moduleName).GetData();
-	
-					DebugLog("Existing VBA source:\n" + GetVBATextFromModuleStream(streamBytes, vbaModule.textOffset));			
-			
+
+					streamBytes = commonStorage.GetStorage("VBA").GetStream(vbaModule.moduleName).GetData();
+
+					DebugLog("Existing VBA source:\n" + GetVBATextFromModuleStream(streamBytes, vbaModule.textOffset));
+
 					// Get new VBA source code from specified text file. If not specified, VBA code is removed completely.
-					string newVBACode = "";				
-					if (VBASourceFileName != "") {
-						try {
+					string newVBACode = "";
+					if (VBASourceFileName != "")
+					{
+						try
+						{
 							newVBACode = System.IO.File.ReadAllText(VBASourceFileName);
 						}
-						catch (Exception e) {
+						catch (Exception e)
+						{
 							Console.WriteLine("ERROR: Could not open VBA source file " + VBASourceFileName);
 							Console.WriteLine("Please make sure this file exists and contains ASCII only characters.");
 							Console.WriteLine();
-							Console.WriteLine(e.Message);						
+							Console.WriteLine(e.Message);
 							return;
 						}
 					}
-				
+
 					DebugLog("Replacing with VBA code:\n" + newVBACode);
-						
+
 					streamBytes = ReplaceVBATextInModuleStream(streamBytes, vbaModule.textOffset, newVBACode);
-			
-					DebugLog("Hex dump of VBA module stream " + vbaModule.moduleName + ":\n" + Utils.HexDump(streamBytes));	
-						
-					cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream(vbaModule.moduleName).SetData(streamBytes);
+
+					DebugLog("Hex dump of VBA module stream " + vbaModule.moduleName + ":\n" + Utils.HexDump(streamBytes));
+
+					commonStorage.GetStorage("VBA").GetStream(vbaModule.moduleName).SetData(streamBytes);
 				}
 			}
 		}
 
 		// Set random ASCII names for VBA modules in dir stream
-		if (optionSetRandomNames) {
+		if (optionSetRandomNames)
+		{
 			Console.WriteLine("Setting random ASCII names for VBA modules in dir stream (while leaving unicode names intact).");
-			
+
 			// Recompress and write to dir stream
-			cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("dir").SetData(Compress(SetRandomNamesInDirStream(dirStream)));
+			commonStorage.GetStorage("VBA").GetStream("dir").SetData(Compress(SetRandomNamesInDirStream(dirStream)));
 		}
 
 		// Delete metadata from document
-		if (optionDeleteMetadata) {
-			try {
+		if (optionDeleteMetadata)
+		{
+			try
+			{
 				cf.RootStorage.Delete("\u0005SummaryInformation");
 			}
-			catch (Exception e) {
+			catch (Exception e)
+			{
 				Console.WriteLine("ERROR: metadata stream does not exist (option ignored)");
 				DebugLog(e.Message);
 			}
 		}
 
 		// Commit changes and close file
-		cf.Commit();		
+		cf.Commit();
 		cf.Close();
-		
+
 		// Purge unused space in file
-		CompoundFile.ShrinkCompoundFile(filename);
-		
+		CompoundFile.ShrinkCompoundFile(oleFilename);
+
+		// Zip the file back up as a docm or xlsm
+		if (is_OpenXML)
+		{
+			if (File.Exists(outFilename)) File.Delete(outFilename);
+			ZipFile.CreateFromDirectory(unzipTempPath, outFilename);
+			// Delete Temporary Files
+			Directory.Delete(unzipTempPath, true);
+		}
+
 		// Start web server, if option is specified
-		if (optionWebserverPort != 0) {
-			try {
+		if (optionWebserverPort != 0)
+		{
+			try
+			{
 				WebServer ws = new WebServer(SendFile, "http://*:" + optionWebserverPort.ToString() + "/*");
-	        	ws.Run();
-    	    	Console.WriteLine("Webserver starting on port " + optionWebserverPort.ToString() + ". Press a key to quit.");
-        		Console.ReadKey();
-        		ws.Stop();
-        		Console.WriteLine("Webserver closed. Goodbye!");
-        	}
-        	catch (Exception e) {
-        		Console.WriteLine("ERROR: could not start webserver on specified port");
-        		DebugLog(e.Message);
-        	}
-        }
-    }
-    
-    static public byte[] SendFile(HttpListenerRequest request)
-    {
-        Console.WriteLine("Serving request from " + request.RemoteEndPoint.ToString() + " with user agent " + request.UserAgent);
-        
+				ws.Run();
+				Console.WriteLine("Webserver starting on port " + optionWebserverPort.ToString() + ". Press a key to quit.");
+				Console.ReadKey();
+				ws.Stop();
+				Console.WriteLine("Webserver closed. Goodbye!");
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine("ERROR: could not start webserver on specified port");
+				DebugLog(e.Message);
+			}
+		}
+	}
+
+	public static string getOutFilename(String filename)
+	{
+		string fn = Path.GetFileNameWithoutExtension(filename);
+		string ext = Path.GetExtension(filename);
+		string path = Path.GetDirectoryName(filename);
+		return Path.Combine(path, fn + "_EvilClippy" + ext);
+	}
+
+	public static string CreateUniqueTempDirectory()
+	{
+		var uniqueTempDir = Path.GetFullPath(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+		Directory.CreateDirectory(uniqueTempDir);
+		return uniqueTempDir;
+	}
+
+	static public byte[] SendFile(HttpListenerRequest request)
+	{
+		Console.WriteLine("Serving request from " + request.RemoteEndPoint.ToString() + " with user agent " + request.UserAgent);
+
 		CompoundFile cf = new CompoundFile(filename, CFSUpdateMode.Update, 0);
 
 		CFStream streamData = cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("_VBA_PROJECT");
 		byte[] streamBytes = streamData.GetData();
 
 		string targetOfficeVersion = UserAgentToOfficeVersion(request.UserAgent);
-		
+
 		ReplaceOfficeVersionInVBAProject(streamBytes, targetOfficeVersion);
-	
-		cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("_VBA_PROJECT").SetData(streamBytes);		
-        
-        // Commit changes and close file
-		cf.Commit();		
+
+		cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("_VBA_PROJECT").SetData(streamBytes);
+
+		// Commit changes and close file
+		cf.Commit();
 		cf.Close();
-        
-        return File.ReadAllBytes(filename);        
-    }
-    
-    static string UserAgentToOfficeVersion(string userAgent)
-    {
-    	string officeVersion = "";
-    	
-    	// Determine version number
-    	if (userAgent.Contains("MSOffice 16")) 
-   			officeVersion = "2016";
-   		else if (userAgent.Contains("MSOffice 15"))
-   			officeVersion = "2013";
-    	else
-    		officeVersion = "unknown";
-  		  	
-    	// Determine architecture
-    	if (userAgent.Contains("x64") || userAgent.Contains("Win64"))
-    		officeVersion += "x64";
+
+		return File.ReadAllBytes(filename);
+	}
+
+	static string UserAgentToOfficeVersion(string userAgent)
+	{
+		string officeVersion = "";
+
+		// Determine version number
+		if (userAgent.Contains("MSOffice 16"))
+			officeVersion = "2016";
+		else if (userAgent.Contains("MSOffice 15"))
+			officeVersion = "2013";
+		else
+			officeVersion = "unknown";
+
+		// Determine architecture
+		if (userAgent.Contains("x64") || userAgent.Contains("Win64"))
+			officeVersion += "x64";
 		else
 			officeVersion += "x86";
-			
+
 		DebugLog("Determined Office version from user agent: " + officeVersion);
-    	
-    	return officeVersion;
-    }
-    
-	static void ShowHelp (OptionSet p)
-    {
-        Console.WriteLine("Usage: eviloffice.exe [OPTIONS]+ filename");
-        Console.WriteLine();
+
+		return officeVersion;
+	}
+
+	static void ShowHelp(OptionSet p)
+	{
+		Console.WriteLine("Usage: eviloffice.exe [OPTIONS]+ filename");
+		Console.WriteLine();
 		Console.WriteLine("Author: Stan Hegt");
 		Console.WriteLine("Email: stan@outflank.nl");
-        Console.WriteLine();
-        Console.WriteLine("Options:");
-        p.WriteOptionDescriptions (Console.Out);
-    }
-        
-    static void DebugLog(object args)
-    {
-        if (verbosity > 0) {
-            Console.WriteLine();
-            Console.WriteLine("########## DEBUG OUTPUT: ##########");
-            Console.WriteLine(args);
-            Console.WriteLine("###################################");
-            Console.WriteLine();
-        }
-    }
-    
-    private static byte[] ReplaceOfficeVersionInVBAProject(byte[] moduleStream, string officeVersion) {
+		Console.WriteLine();
+		Console.WriteLine("Options:");
+		p.WriteOptionDescriptions(Console.Out);
+	}
+
+	static void DebugLog(object args)
+	{
+		if (verbosity > 0)
+		{
+			Console.WriteLine();
+			Console.WriteLine("########## DEBUG OUTPUT: ##########");
+			Console.WriteLine(args);
+			Console.WriteLine("###################################");
+			Console.WriteLine();
+		}
+	}
+
+	private static byte[] ReplaceOfficeVersionInVBAProject(byte[] moduleStream, string officeVersion)
+	{
 		byte[] version = new byte[2];
-		
-		switch (officeVersion) {
+
+		switch (officeVersion)
+		{
 			case "2010x86":
 				version[0] = 0x97;
 				version[1] = 0x00;
@@ -326,88 +408,90 @@ public class MSOfficeManipulator
 				Console.WriteLine("ERROR: Incorrect MS Office version specified - skipping this step.");
 				return moduleStream;
 		}
-		
+
 		Console.WriteLine("Targeting pcode on Office version: " + officeVersion);
-		
+
 		moduleStream[2] = version[0];
 		moduleStream[3] = version[1];
-		
+
 		return moduleStream;
 	}
-    
-    private static byte[] ReplaceVBATextInModuleStream(byte[] moduleStream, UInt32 textOffset, string newVBACode) {
-    	return moduleStream.Take((int)textOffset).Concat(Compress(Encoding.UTF8.GetBytes(newVBACode))).ToArray();
-    }
-    
-    private static string GetVBATextFromModuleStream(byte[] moduleStream, UInt32 textOffset) {
-    	string vbaModuleText = System.Text.Encoding.UTF8.GetString(Decompress(moduleStream.Skip((int)textOffset).ToArray()));
-    
-    	return vbaModuleText;
-    }
 
-    private static byte[] SetRandomNamesInDirStream(byte[] dirStream)
-    {   
-    	// 2.3.4.2 dir Stream: Version Independent Project Information
-    	// https://msdn.microsoft.com/en-us/library/dd906362(v=office.12).aspx
-    	// Dir stream is ALWAYS in little endian
-     	
+	private static byte[] ReplaceVBATextInModuleStream(byte[] moduleStream, UInt32 textOffset, string newVBACode)
+	{
+		return moduleStream.Take((int)textOffset).Concat(Compress(Encoding.UTF8.GetBytes(newVBACode))).ToArray();
+	}
+
+	private static string GetVBATextFromModuleStream(byte[] moduleStream, UInt32 textOffset)
+	{
+		string vbaModuleText = System.Text.Encoding.UTF8.GetString(Decompress(moduleStream.Skip((int)textOffset).ToArray()));
+
+		return vbaModuleText;
+	}
+
+	private static byte[] SetRandomNamesInDirStream(byte[] dirStream)
+	{
+		// 2.3.4.2 dir Stream: Version Independent Project Information
+		// https://msdn.microsoft.com/en-us/library/dd906362(v=office.12).aspx
+		// Dir stream is ALWAYS in little endian
+
 		int offset = 0;
 		UInt16 tag;
 		UInt32 wLength;
-		
+
 		while (offset < dirStream.Length)
-        {
+		{
 			tag = GetWord(dirStream, offset);
 			wLength = GetDoubleWord(dirStream, offset + 2);
-			        	
+
 			// The following idiocy is because Microsoft can't stick to their own format specification - taken from Pcodedmp
-            if (tag == 9)
-                wLength = 6;
-            else if (tag == 3)
-                wLength = 2;       	
-        	
-        	switch (tag)
-        	{
+			if (tag == 9)
+				wLength = 6;
+			else if (tag == 3)
+				wLength = 2;
+
+			switch (tag)
+			{
 				case 26: // 2.3.4.2.3.2.3 MODULESTREAMNAME Record
 					System.Text.UTF8Encoding encoding = new System.Text.UTF8Encoding();
 					encoding.GetBytes(Utils.RandomString((int)wLength), 0, (int)wLength, dirStream, (int)offset + 6);
-					
+
 					break;
-        	}
-        	
-        	offset += 6;
-        	offset += (int)wLength;
-        }
-    
-    	return dirStream;
-    }
-    
-    private static List<ModuleInformation> ParseModulesFromDirStream(byte[] dirStream)
-    {   
-    	// 2.3.4.2 dir Stream: Version Independent Project Information
-    	// https://msdn.microsoft.com/en-us/library/dd906362(v=office.12).aspx
-    	// Dir stream is ALWAYS in little endian
-     	
-    	List<ModuleInformation> modules = new List<ModuleInformation>();
+			}
+
+			offset += 6;
+			offset += (int)wLength;
+		}
+
+		return dirStream;
+	}
+
+	private static List<ModuleInformation> ParseModulesFromDirStream(byte[] dirStream)
+	{
+		// 2.3.4.2 dir Stream: Version Independent Project Information
+		// https://msdn.microsoft.com/en-us/library/dd906362(v=office.12).aspx
+		// Dir stream is ALWAYS in little endian
+
+		List<ModuleInformation> modules = new List<ModuleInformation>();
 
 		int offset = 0;
 		UInt16 tag;
 		UInt32 wLength;
 		ModuleInformation currentModule = new ModuleInformation { moduleName = "", textOffset = 0 };
-		
+
 		while (offset < dirStream.Length)
-        {
+		{
 			tag = GetWord(dirStream, offset);
 			wLength = GetDoubleWord(dirStream, offset + 2);
-			        	
+
 			// The following idiocy is because Microsoft can't stick to their own format specification - taken from Pcodedmp
-            if (tag == 9)
-                wLength = 6;
-            else if (tag == 3)
-                wLength = 2;       	
-        	
-        	switch (tag)
-        	{
+			if (tag == 9)
+				wLength = 6;
+			else if (tag == 3)
+				wLength = 2;
+
+			switch (tag)
+			{
 				case 26: // 2.3.4.2.3.2.3 MODULESTREAMNAME Record
 					currentModule.moduleName = System.Text.Encoding.UTF8.GetString(dirStream, (int)offset + 6, (int)wLength);
 					break;
@@ -415,54 +499,54 @@ public class MSOfficeManipulator
 					currentModule.textOffset = GetDoubleWord(dirStream, offset + 6);
 					modules.Add(currentModule);
 					currentModule = new ModuleInformation { moduleName = "", textOffset = 0 };
-					break;        	
-        	}
-        	
-        	offset += 6;
-        	offset += (int)wLength;
-        }
-    
-    	return modules;
-    }
-    
+					break;
+			}
+
+			offset += 6;
+			offset += (int)wLength;
+		}
+
+		return modules;
+	}
+
 	public class ModuleInformation
 	{
 		public string moduleName; // Name of VBA module stream
-		
+
 		public UInt32 textOffset; // Offset of VBA source code in VBA module stream
 	}
-    
-    private static UInt16 GetWord(byte[] buffer, int offset)
-    {
-    	var rawBytes = new byte[2];
-    	    	
-    	Array.Copy(buffer, offset, rawBytes, 0, 2);
+
+	private static UInt16 GetWord(byte[] buffer, int offset)
+	{
+		var rawBytes = new byte[2];
+
+		Array.Copy(buffer, offset, rawBytes, 0, 2);
 		//if (!BitConverter.IsLittleEndian) {
 		//	Array.Reverse(rawBytes);
 		//}
 
 		return BitConverter.ToUInt16(rawBytes, 0);
-    }
+	}
 
-    private static UInt32 GetDoubleWord(byte[] buffer, int offset)
-    {
-    	var rawBytes = new byte[4];
-    	    	
-    	Array.Copy(buffer, offset, rawBytes, 0, 4);
+	private static UInt32 GetDoubleWord(byte[] buffer, int offset)
+	{
+		var rawBytes = new byte[4];
+
+		Array.Copy(buffer, offset, rawBytes, 0, 4);
 		//if (!BitConverter.IsLittleEndian) {
 		//	Array.Reverse(rawBytes);
 		//}
 
 		return BitConverter.ToUInt32(rawBytes, 0);
-    }
-    
-    private static byte[] Compress(byte[] data)
-    {
+	}
+
+	private static byte[] Compress(byte[] data)
+	{
 		var buffer = new DecompressedBuffer(data);
 		var container = new CompressedContainer(buffer);
 		return container.SerializeData();
 	}
-	
+
 	private static byte[] Decompress(byte[] data)
 	{
 		var container = new CompressedContainer(data);
@@ -482,22 +566,22 @@ public class WebServer
 	{
 		if (!HttpListener.IsSupported)
 			throw new NotSupportedException("Needs Windows XP SP2, Server 2003 or later.");
- 
+
 		// URI prefixes are required, for example "http://localhost:8080/index/".
-        if (prefixes == null || prefixes.Length == 0)
-        	throw new ArgumentException("prefixes");
+		if (prefixes == null || prefixes.Length == 0)
+			throw new ArgumentException("prefixes");
 
 		// A responder method is required
 		if (method == null)
 			throw new ArgumentException("method");
- 
+
 		foreach (string s in prefixes)
 			_listener.Prefixes.Add(s);
- 
+
 		_responderMethod = method;
 		_listener.Start();
 	}
- 
+
 	public void Run()
 	{
 		ThreadPool.QueueUserWorkItem((o) =>


### PR DESCRIPTION
I changed the code to not overwrite the original file, but instead write a new file with "_EvilClippy" appended to the end. This made my testing so much easier to not have my originals disappearing.

I also updated readme with:
1) additional dll requirement for build
2) limitation that VBA stomping does not work on XLS files at this time.