### PR TITLE
Fixing 64 bit identification by User Agent

### DIFF
--- a/evilclippy.cs
+++ b/evilclippy.cs
@@ -5,7 +5,7 @@
 // Date: 20200415
 // Version: 1.3 (added GUI unhide option)
 //
-// Special thanks to Carrie Roberts (@OrOneEqualsOne) from Walmart for her contributions to this project.
+// Special thanks to Carrie Robberts (@OrOneEqualsOne) from Walmart for her contributions to this project.
 //
 // Compilation instructions
 // Mono: mcs /reference:OpenMcdf.dll,System.IO.Compression.FileSystem.dll /out:EvilClippy.exe *.cs 
@@ -445,7 +445,14 @@ public class MSOfficeManipulator
 		CFStream streamData = cf.RootStorage.GetStorage("Macros").GetStorage("VBA").GetStream("_VBA_PROJECT");
 		byte[] streamBytes = streamData.GetData();
 
-		string targetOfficeVersion = UserAgentToOfficeVersion(request.UserAgent);
+		string UACpu = "";
+		if (request.Headers["UA-CPU"] != null)
+        {
+			UACpu = request.Headers["UA-CPU"];
+
+		}
+
+		string targetOfficeVersion = UserAgentToOfficeVersion(request.UserAgent, UACpu);
 
 		ReplaceOfficeVersionInVBAProject(streamBytes, targetOfficeVersion);
 
@@ -459,7 +466,7 @@ public class MSOfficeManipulator
 		return File.ReadAllBytes(outFilename);
 	}
 
-	static string UserAgentToOfficeVersion(string userAgent)
+	static string UserAgentToOfficeVersion(string userAgent, string UACpu)
 	{
 		string officeVersion = "";
 
@@ -472,7 +479,7 @@ public class MSOfficeManipulator
 			officeVersion = "unknown";
 
 		// Determine architecture
-		if (userAgent.Contains("x64") || userAgent.Contains("Win64"))
+		if (userAgent.Contains("x64") || userAgent.Contains("Win64") || UACpu.Contains("64"))
 			officeVersion += "x64";
 		else
 			officeVersion += "x86";
@@ -520,10 +527,6 @@ public class MSOfficeManipulator
 				version[1] = 0x00;
 				break;
 			case "2016x86":
-				version[0] = 0xAF;
-				version[1] = 0x00;
-				break;
-			case "2019x86":
 				version[0] = 0xAF;
 				version[1] = 0x00;
 				break;


### PR DESCRIPTION
I have recently identified that Office 2016 actually uses another header to differentiate 64bits from 32bit:

UA-CPU: AMD64

The current version of EvilClippy is not able to serve the correct template because it is not analyzing the value of this header, so it ends up serving x86 template for x64.

I'm not sure if that happens to other versions, so I just added another check for this specific header and the presence of the string "64" in the value of the header.

